### PR TITLE
filter out containers not managed by rancher

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,8 @@ function getHostContainers(hostUUID){
                 var output = {};
                 output.containers = JSON.parse(body).filter(
                     function(container) {
-                        return container.host_uuid == hostUUID;
+                        return container.host_uuid == hostUUID
+                          && container.labels['io.rancher.container.uuid'];
                     }
                 );
                 resolve(output);


### PR DESCRIPTION
This limits rancher-registrator from registering containers not actually managed by rancher using a heuristic label check; allowing registrator and rancher-registrator to coexist peacefully without stepping on eachother's foot.