### PR TITLE
Add support for external consul instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-ST
 ### Introduction
 The aim of this project is to achieve a third party registration in consul for every containers deployed through rancher. Since the release of Rancher v1.2.0 and its migration to the CNI framework, registrator isn't able to see containers port mappings anymore.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+ST
 ### Introduction
 The aim of this project is to achieve a third party registration in consul for every containers deployed through rancher. Since the release of Rancher v1.2.0 and its migration to the CNI framework, registrator isn't able to see containers port mappings anymore.
 
@@ -29,7 +30,7 @@ It also needs to be mapped on the docker.sock file of the host :
 You can set 2 environment variables :
 
  - SVC_PREFIX is used to prefix the service name into consul (for testing purpose)
- - LOCAL_CONSUL_AGENT defaults to "http://localhost:8500" and it can be changed if necessary.
+ - CONSUL_HOST defaults to "http://localhost:8500" and it can be changed if necessary.
 
 ### Labels
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var emitter = new DockerEvents({
 var jsonQuery = require('json-query')
 
 var _prefix = process.env.SVC_PREFIX || "";
-var _consulAgent = process.env.LOCAL_CONSUL_AGENT || "http://localhost:8500";
+var _consulAgent = process.env.CONSUL_HOST || "http://localhost:8500";
 
 
 Array.prototype.flatten = function() {
@@ -81,7 +81,8 @@ function getHostContainers(hostUUID){
                 "method":"GET",
                 "url": "http://rancher-metadata/latest/containers",
                 "headers":{
-                    "accept" : "application/json"
+                    "accept" : "application/json",
+                    "X-Consul-Token" : process.env.CONSUL_HTTP_TOKEN           
                 }
             }
 
@@ -145,7 +146,8 @@ function getMetaData(servicename){
                 "method":"GET",
                 "url": "http://rancher-metadata/latest/containers/" + servicename,
                 "headers":{
-                    "accept" : "application/json"
+                    "accept" : "application/json",
+                    "X-Consul-Token" : process.env.CONSUL_HTTP_TOKEN           
                 }
             }
 
@@ -172,7 +174,8 @@ function getHostUUID(){
                 "method":"GET",
                 "url": "http://rancher-metadata/latest/self/host",
                 "headers":{
-                    "accept" : "application/json"
+                    "accept" : "application/json",
+                    "X-Consul-Token" : process.env.CONSUL_HTTP_TOKEN           
                 }
             }
 
@@ -196,7 +199,8 @@ function getAgentIP(input){
                 "method":"GET",
                 "url": "http://rancher-metadata/latest/self/host",
                 "headers":{
-                    "accept" : "application/json"
+                    "accept" : "application/json",
+                    "X-Consul-Token" : process.env.CONSUL_HTTP_TOKEN           
                 }
             }
 
@@ -457,7 +461,8 @@ function doRegister(serviceDef,callback){
         "method":"PUT",
         "url": _consulAgent + "/v1/agent/service/register",
         "headers":{
-            "Content-Type" : "application/json"
+            "Content-Type" : "application/json",
+            "X-Consul-Token" : process.env.CONSUL_HTTP_TOKEN
         },
         "json":serviceDef
     };


### PR DESCRIPTION
I've forked your repo to add the ability to utilise a Consul ACL for HTTP auth when registering to Consul and dealing with things inside Consul from your application. In addition I've updated the readme and changed 'LOCAL_CONSUL_AGENT' to a more generic 'CONSUL_HOST' to remove the assumption that this is only compatible with local Consul instances.

If you're happy with my changes, please feel free to merge them in! Thanks.