### PR TITLE
Fix deregister

### DIFF
--- a/index.js
+++ b/index.js
@@ -474,7 +474,7 @@ function doRegister(serviceDef,callback){
 
 function doDeregister(uuid,callback){
     var query = {
-        "method":"GET",
+        "method":"PUT",
         "url": _consulAgent + "/v1/agent/service/deregister/" + uuid,
     };
 


### PR DESCRIPTION
Deregister was broken for us -- it mostly showed it's face when we scaled down in Rancher or a container moved hosts during an upgrade. This change has been working for us and reduces the need for cleanup / scheduled restarts.